### PR TITLE
ray-cli: Add `legacy-peer-deps=true` to `.npmrc`

### DIFF
--- a/ray-cli/ray_cli.sh
+++ b/ray-cli/ray_cli.sh
@@ -115,6 +115,7 @@ for dir in "${paths[@]}" ; do
         else
             echo "//npm.pkg.github.com/:_authToken=$npm_token" > .npmrc
             echo "@raycast:registry=https://npm.pkg.github.com" >> .npmrc
+            echo "legacy-peer-deps=true" >> .npmrc
             cleanup_npmrc=true
         fi
     fi


### PR DESCRIPTION
This PR adds `legacy-peer-deps=true` to `.npmrc`, to allow `npm ci` to resolve dependencies for extensions that depend on the internal API _and_ use `@raycast/utils`.