### PR TITLE
RayCLI: Fix multiple store URLs

### DIFF
--- a/ray-cli/ray_cli.sh
+++ b/ray-cli/ray_cli.sh
@@ -182,8 +182,6 @@ done
 
 # encode multiline output for github actions
 store_urls_string=$(printf "%s\n" "${store_urls[@]}")
-store_urls_string="${store_urls_string//'%'/'%25'}"
-store_urls_string="${store_urls_string//$'\n'/'%0A'}"
-store_urls_string="${store_urls_string//$'\r'/'%0D'}"
+store_urls_string="${store_urls_string//$'\n'/ }"
 echo "store_urls=${store_urls_string}" >> $GITHUB_OUTPUT
 exit $exit_code


### PR DESCRIPTION
Hi @mathieudutour. This fixes the message at https://github.com/raycast/extensions/pull/14917#issuecomment-2413232135. It has a `'%0A'` between the store URLs.

As I understand, there should be no `%` and `\r` in the URL. So those steps can be removed.

Please correct me if I'm wrong.