### PR TITLE
Generate provenance statements when publishing

### DIFF
--- a/publish-npm/action.yml
+++ b/publish-npm/action.yml
@@ -36,7 +36,7 @@ runs:
         echo "Registry version: $public_version"
 
         if [[ "$version" != "$public_version" ]]; then
-            npm publish
+            npm publish --provenance --access public
             echo "version=$version" >> $GITHUB_OUTPUT
         else
             echo "Skipping API publishing"

--- a/publish-npm/action.yml
+++ b/publish-npm/action.yml
@@ -36,7 +36,7 @@ runs:
         echo "Registry version: $public_version"
 
         if [[ "$version" != "$public_version" ]]; then
-            npm publish --provenance --access public
+            npm publish --provenance
             echo "version=$version" >> $GITHUB_OUTPUT
         else
             echo "Skipping API publishing"


### PR DESCRIPTION
Documentation: https://docs.npmjs.com/generating-provenance-statements

It looks like your `publish-npm` in-use actions are private. You need to add a new permission field to those actions to apply the provenance change:

```yaml
permissions:
  id-token: write
```