### PR TITLE
ray-cli: stream npm ci output instead of running it silently

### DIFF
--- a/ray-cli/ray_cli.sh
+++ b/ray-cli/ray_cli.sh
@@ -142,7 +142,11 @@ for dir in "${paths[@]}" ; do
     set -e
 
     if [ $last_exit_code -ne 0 ]; then
-        echo "::error::Npm ci failed for $extension_folder"
+        error_message=$(grep -E '^npm (error|ERR!)' $ray_ci_log_file | head -5 | tr '\n' ' ')
+        if [ -z "$error_message" ]; then
+            error_message=$(tail -1 $ray_ci_log_file)
+        fi
+        echo "::error title=npm ci failed for $extension_folder::$error_message"
         exit_code=1
         continue
     fi

--- a/ray-cli/ray_cli.sh
+++ b/ray-cli/ray_cli.sh
@@ -135,18 +135,14 @@ for dir in "${paths[@]}" ; do
         fi
     fi
 
-    # npm ci doesn't allow us to silence output properly
-    # run it silently first and if it fails run it without silencing
+    # stream npm output so failures and hangs are visible in the log
     set +e
-    npm ci --silent
+    npm ci --no-audit --no-fund --loglevel=error 2>&1 | tee $ray_ci_log_file ; test ${PIPESTATUS[0]} -eq 0
     last_exit_code=${?}
     set -e
 
     if [ $last_exit_code -ne 0 ]; then
         echo "::error::Npm ci failed for $extension_folder"
-        set +e
-        npm ci
-        set -e
         exit_code=1
         continue
     fi


### PR DESCRIPTION
## Context

Every `ticktick` publish since November has silently hung in the "Run Ray CLI" step until GitHub's 6-hour job timeout (e.g. [this run](https://github.com/raycast/extensions/actions/runs/30245192192/job/89910582497), and raycast/extensions#29568's publish sat for ~84h before being cancelled). The log shows `Entering .../extensions/ticktick` and then nothing — because the very next command is `npm ci --silent`, which suppresses all output while npm wedges on the extension's out-of-sync `package-lock.json` (npm 10.7 on the runners doesn't fast-fail on lock/manifest mismatches like npm ≥10.9 does; it goes into peer-dep resolution instead).

## Change

- Run `npm ci` once, streaming output through `tee` (same idiom as the `ray validate`/`ray build` calls below), so failures — and whatever npm last printed before a hang — are visible in the log. Capturing into a variable was deliberately avoided: it would only print after npm exits, hiding hangs again.
- `--loglevel=error --no-audit --no-fund` keeps the success path close to silent (one summary line per extension).
- Drop the second verbose `npm ci` fallback: the error is now visible from the first run, and re-running doubled the work (or the hang).

Deliberately **not** adding a timeout yet — this is the observability step so the next ticktick run shows what npm is actually doing.

## Testing

- `bash -n ray_cli.sh`
- Verified locally that `npm ci --no-audit --no-fund --loglevel=error` on a healthy extension prints only the final summary line, and prints the full error on an out-of-sync lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)